### PR TITLE
Fixed issue with repeated invalid serial in db

### DIFF
--- a/app.py
+++ b/app.py
@@ -187,7 +187,7 @@ def check_serial(serial):
 
     query = f"SELECT * FROM invalids WHERE invalid_serial == '{serial}'"
     results = cur.execute(query)
-    if len(results.fetchall()) == 1:
+    if len(results.fetchall()) > 0:
         return 'this serial is among failed ones' #TODO: return the string provided by the customer
 
     query = f"SELECT * FROM serials WHERE start_serial < '{serial}' and end_serial > '{serial}';"


### PR DESCRIPTION
If an invalid serial is repeated multiple times in db, the program fails to announce it as invalid