### PR TITLE
Add Linux, macOS and windows useless files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,77 @@ dmypy.json
 # Pyre type checker
 .pyre/
 config.py
+
+# Created by https://www.gitignore.io/api/windows,macos,linux
+# Edit at https://www.gitignore.io/?templates=windows,macos,linux
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.gitignore.io/api/windows,macos,linux


### PR DESCRIPTION
I've noticed in https://github.com/jadijadi/sms_serial_verification/pull/14 that some useless files in macOS (for example .DS_Store) were added to the repository, so I updated .gitignore file.
Useless files from Linux, macOS and windows are not going to bother anyone again :) .
Everything I added to .gitignore is coming from [this site.](https://www.gitignore.io/api/windows,macos,linux)