### PR TITLE
Solve problem caused by naming 2 method exactly the same

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -145,7 +145,7 @@ def logout():
 
 #
 @app.errorhandler(401)
-def page_not_found(error):
+def unauthorized(error):
     """ handling login failures"""
     flash('Login problem', 'danger')
     return redirect('/login')
@@ -386,7 +386,7 @@ def process():
 
 
 @app.errorhandler(404)
-def page_not_found():
+def page_not_found(error):
     """ returns 404 page"""
     return render_template('404.html'), 404
 


### PR DESCRIPTION
For error 401 and 404 you had a method with the same name, I changed the name of method for 401 error to unauthorized.