### PR TITLE
Refactor normalize string function

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -216,8 +216,8 @@ def normalize_string(serial_number, fixed_size=30):
     serial_number = _translate_numbers(persian_numerals, english_numerals, serial_number)
     serial_number = _translate_numbers(arabic_numerals, english_numerals, serial_number)
 
-    all_digit = re.findall("\d", serial_number)
-    all_alpha = re.findall("[A-Z]", serial_number)
+    all_digit = "".join(re.findall("\d", serial_number))
+    all_alpha = "".join(re.findall("[A-Z]", serial_number))
 
     missing_zeros = "0" * (fixed_size - len(all_alpha + all_digit))
 

--- a/app/main.py
+++ b/app/main.py
@@ -346,7 +346,8 @@ def check_serial(serial):
     with db.cursor() as cur:
         results = cur.execute("SELECT * FROM invalids WHERE invalid_serial = %s", (serial,))
         if results > 0:
-            answer = dedent(f"""{original_serial}
+            answer = dedent(f"""\
+                {original_serial}
                 این شماره هولوگرام یافت نشد. لطفا دوباره سعی کنید  و یا با واحد پشتیبانی تماس حاصل فرمایید.
                 ساختار صحیح شماره هولوگرام بصورت دو حرف انگلیسی و 7 یا 8 رقم در دنباله آن می باشد. مثال:
                 FA1234567
@@ -357,7 +358,8 @@ def check_serial(serial):
 
         results = cur.execute("SELECT * FROM serials WHERE start_serial <= %s and end_serial >= %s", (serial, serial))
         if results > 1:
-            answer = dedent(f"""{original_serial}
+            answer = dedent(f"""\
+                {original_serial}
                 این شماره هولوگرام مورد تایید است.
                 برای اطلاعات بیشتر از نوع محصول با بخش پشتیبانی فروش شرکت التک تماس حاصل فرمایید:
                 021-22038385""")
@@ -368,7 +370,8 @@ def check_serial(serial):
             ref_number = ret[1]
             date = ret[5].date()
             print(type(date))
-            answer = dedent(f"""{original_serial}
+            answer = dedent(f"""\
+                {original_serial}
                 {ref_number}
                 {desc}
                 Hologram date: {date}
@@ -378,7 +381,8 @@ def check_serial(serial):
             return 'OK', answer
 
 
-    answer = dedent(f"""{original_serial}
+    answer = dedent(f"""\
+        {original_serial}
         این شماره هولوگرام یافت نشد. لطفا دوباره سعی کنید  و یا با واحد پشتیبانی تماس حاصل فرمایید.
         ساختار صحیح شماره هولوگرام بصورت دو حرف انگلیسی و 7 یا 8 رقم در دنباله آن می باشد. مثال:
         FA1234567

--- a/app/main.py
+++ b/app/main.py
@@ -1,16 +1,36 @@
-import re
-import os
-import time
-import requests
 import datetime
-from flask import Flask, flash, jsonify, request, Response, redirect, url_for, abort, render_template
-from flask_login import LoginManager, UserMixin, login_required, login_user, logout_user, current_user
-from pandas import read_excel
+import os
+import re
+import time
+from textwrap import dedent
+
+import requests
+from flask import (
+    Flask,
+    Response,
+    abort,
+    flash,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
 from werkzeug.utils import secure_filename
-import MySQLdb
+
 import config
+import MySQLdb
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
+from flask_login import (
+    LoginManager,
+    UserMixin,
+    current_user,
+    login_required,
+    login_user,
+    logout_user,
+)
+from pandas import read_excel
 
 app = Flask(__name__)
 limiter = Limiter(app, key_func=get_remote_address)
@@ -326,21 +346,21 @@ def check_serial(serial):
     with db.cursor() as cur:
         results = cur.execute("SELECT * FROM invalids WHERE invalid_serial = %s", (serial,))
         if results > 0:
-            answer = f'''{original_serial}
-    این شماره هولوگرام یافت نشد. لطفا دوباره سعی کنید  و یا با واحد پشتیبانی تماس حاصل فرمایید.
-    ساختار صحیح شماره هولوگرام بصورت دو حرف انگلیسی و 7 یا 8 رقم در دنباله آن می باشد. مثال:
-    FA1234567
-    شماره تماس با بخش پشتیبانی فروش شرکت التک:
-    021-22038385'''
+            answer = dedent(f"""{original_serial}
+                این شماره هولوگرام یافت نشد. لطفا دوباره سعی کنید  و یا با واحد پشتیبانی تماس حاصل فرمایید.
+                ساختار صحیح شماره هولوگرام بصورت دو حرف انگلیسی و 7 یا 8 رقم در دنباله آن می باشد. مثال:
+                FA1234567
+                شماره تماس با بخش پشتیبانی فروش شرکت التک:
+                021-22038385""")
 
             return 'FAILURE', answer
 
         results = cur.execute("SELECT * FROM serials WHERE start_serial <= %s and end_serial >= %s", (serial, serial))
         if results > 1:
-            answer = f'''{original_serial}
-    این شماره هولوگرام مورد تایید است.
-    برای اطلاعات بیشتر از نوع محصول با بخش پشتیبانی فروش شرکت التک تماس حاصل فرمایید:
-    021-22038385'''
+            answer = dedent(f"""{original_serial}
+                این شماره هولوگرام مورد تایید است.
+                برای اطلاعات بیشتر از نوع محصول با بخش پشتیبانی فروش شرکت التک تماس حاصل فرمایید:
+                021-22038385""")
             return 'DOUBLE', answer
         elif results == 1:
             ret = cur.fetchone()
@@ -348,22 +368,22 @@ def check_serial(serial):
             ref_number = ret[1]
             date = ret[5].date()
             print(type(date))
-            answer = f'''{original_serial}
-    {ref_number}
-    {desc}
-    Hologram date: {date}
-    Genuine product of Schneider Electric
-    شماره تماس با بخش پشتیبانی فروش شرکت التک:
-    021-22038385'''
+            answer = dedent(f"""{original_serial}
+                {ref_number}
+                {desc}
+                Hologram date: {date}
+                Genuine product of Schneider Electric
+                شماره تماس با بخش پشتیبانی فروش شرکت التک:
+                021-22038385""")
             return 'OK', answer
 
 
-    answer = f'''{original_serial}
-    این شماره هولوگرام یافت نشد. لطفا دوباره سعی کنید  و یا با واحد پشتیبانی تماس حاصل فرمایید.
-    ساختار صحیح شماره هولوگرام بصورت دو حرف انگلیسی و 7 یا 8 رقم در دنباله آن می باشد. مثال:
-    FA1234567
-    شماره تماس با بخش پشتیبانی فروش شرکت التک:
-    021-22038385'''
+    answer = dedent(f"""{original_serial}
+        این شماره هولوگرام یافت نشد. لطفا دوباره سعی کنید  و یا با واحد پشتیبانی تماس حاصل فرمایید.
+        ساختار صحیح شماره هولوگرام بصورت دو حرف انگلیسی و 7 یا 8 رقم در دنباله آن می باشد. مثال:
+        FA1234567
+        شماره تماس با بخش پشتیبانی فروش شرکت التک:
+        021-22038385""")
 
     return 'NOT-FOUND', answer
 

--- a/app/main.py
+++ b/app/main.py
@@ -205,32 +205,32 @@ def normalize_string(serial_number, fixed_size=30):
     """ gets a serial number and standardize it as following:
     >> converts(removes others) all chars to English upper letters and numbers
     >> adds zeros between letters and numbers to make it fixed length """
-    # remove any non-alphanumeric character
-    serial_number = re.sub(r'\W+', '', serial_number)
+
+    serial_number = _remove_non_alphanum_char(serial_number)
     serial_number = serial_number.upper()
 
-    # replace persian and arabic numeric chars to standard format
-    from_persian_char = '۱۲۳۴۵۶۷۸۹۰'
-    from_arabic_char = '١٢٣٤٥٦٧٨٩٠'
-    to_char = '1234567890'
-    for i in range(len(to_char)):
-        serial_number = serial_number.replace(from_persian_char[i], to_char[i])
-        serial_number = serial_number.replace(from_arabic_char[i], to_char[i])
+    persian_numerals = '۱۲۳۴۵۶۷۸۹۰'
+    arabic_numerals = '١٢٣٤٥٦٧٨٩٠'
+    english_numerals = '1234567890'
 
-    # separate the alphabetic and numeric part of the serial number
-    all_alpha = ''
-    all_digit = ''
-    for c in serial_number:
-        if c.isalpha():
-            all_alpha += c
-        elif c.isdigit():
-            all_digit += c
+    serial_number = _translate_numbers(persian_numerals, english_numerals, serial_number)
+    serial_number = _translate_numbers(arabic_numerals, english_numerals, serial_number)
 
-    # add zeros between alphabetic and numeric parts to standardaize the length of the serial number
-    missing_zeros = fixed_size - len(all_alpha) - len(all_digit)
-    serial_number = all_alpha + '0' * missing_zeros + all_digit
+    all_digit = re.findall("\d", serial_number)
+    all_alpha = re.findall("[A-Z]", serial_number)
 
-    return serial_number
+    missing_zeros = "0" * (fixed_size - len(all_alpha + all_digit))
+
+    return f"{all_alpha}{missing_zeros}{all_digit}"
+
+
+def _remove_non_alphanum_char(string):
+    return re.sub(r'\W+', '', string)
+
+
+def _translate_numbers(current, new, string):
+    translation_table = str.maketrans(current, new)
+    return translation_table.translate(string)
 
 
 def import_database_from_excel(filepath):


### PR DESCRIPTION
Hi,

I this PR, which has 2 commits in common with [the previous one](https://github.com/jadijadi/sms_serial_verification/pull/57), I just refactored the `normalize_string` method. I made the code a little bit self-explanatory by introducing two additional functions:
*  `_remove_non_alphanum_char`
* `_translate_numbers`: A more generic way to translate/replace strings in Python.

And finally, I used the `re.findall` function to extract all numbers and alphabetical characters.